### PR TITLE
CASMINST-5622 Restore `DOCKER_ARGS`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,4 +152,4 @@ version:
 	@go version
 
 image:
-	docker build --pull --tag '${NAME}:${VERSION}' .
+	docker build --pull ${DOCKER_ARGS} --tag '${NAME}:${VERSION}' .


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMINST-5622
- Relates to: #26 #29 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Several meta labels are missing from the built image that were provided via `$DOCKER_ARGS`, this is preventing basecamp's systemd service from starting properly. The `DOCKER_ARGS` argument  was removed in #26. The removal was a mistake, and `DOCKER_ARGS`  was restored in the `Jenkinsfile` via #29 however the `Makefile` was missed. This change restores the missing change in the `Makefile`.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

I purged metal-basecamp on redbull, and installed this feature RPM. Basecamp started okay afterwards.

Purge:

```bash
redbull-ncn-m001-pit:~ # podman container list
CONTAINER ID  IMAGE                                                      COMMAND               CREATED       STATUS          PORTS       NAMES
0a1a49756c57  artifactory.algol60.net/csm-docker/stable/nexus3:3.25.0-2  sh -c ${SONATYPE_...  2 months ago  Up 8 weeks ago              nexus
redbull-ncn-m001-pit:~ # podman container list --all
CONTAINER ID  IMAGE                                                           COMMAND               CREATED       STATUS                     PORTS       NAMES
0a1a49756c57  artifactory.algol60.net/csm-docker/stable/nexus3:3.25.0-2       sh -c ${SONATYPE_...  2 months ago  Up 8 weeks ago                         nexus
b1da00985bcc  artifactory.algol60.net/csm-docker/stable/metal-basecamp:1.2.0                        8 weeks ago   Exited (2) 26 seconds ago              basecamp
redbull-ncn-m001-pit:~ # podman container rm b1da00985bcc
b1da00985bccbc3d16e46e82b6b7cf6ba0f86c4731f28b23d9d12934283f7cee
redbull-ncn-m001-pit:~ # podman rmi ba6a0bde08b5
Untagged: artifactory.algol60.net/csm-docker/stable/metal-basecamp:1.2.0
Deleted: ba6a0bde08b5afb381d8238242f5509da10d0cb797f7f110a3ecd76429c5e3d7
redbull-ncn-m001-pit:~ # rpm -e metal-basecamp
```

Install/test:

```bash
redbull-ncn-m001-pit:~ # systemctl status basecamp
● basecamp.service - Basecamp cloud-init server
     Loaded: loaded (/usr/lib/systemd/system/basecamp.service; disabled; vendor preset: disabled)
     Active: active (running) since Tue 2022-11-22 19:30:07 UTC; 4s ago
       Docs: https://github.com/Cray-HPE/metal-basecamp/blob/main/README.md
    Process: 74654 ExecStart=/usr/sbin/basecamp-init.sh /run/basecamp.service-pid /run/basecamp.service-cid basecamp (code=exited, status=0/SUCCESS)
   Main PID: 75250 (conmon)
      Tasks: 2
     CGroup: /system.slice/basecamp.service
             └─75250 /usr/bin/conmon --api-version 1 -c fe7b800498fa42de7f37a2f54464f0939e0562c9540dd3d33f703c0f7bdebc5a -u fe7b800498fa42de7f37a2f54464f0939e0562c9540dd3d33f703c0f7bdebc5a -r /usr/bin/runc -b /var/lib/containers/storage/overlay-containers/fe7b800498fa42de7f37a2f54>

Nov 22 19:30:06 redbull-ncn-m001-pit podman[75145]: 2022-11-22 19:30:06.543684389 +0000 UTC m=+0.109907864 container create fe7b800498fa42de7f37a2f54464f0939e0562c9540dd3d33f703c0f7bdebc5a (image=artifactory.algol60.net/csm-docker/unstable/metal-basecamp:1.2.2_1_gaec949b, name=bas>
Nov 22 19:30:06 redbull-ncn-m001-pit basecamp-init.sh[75145]: fe7b800498fa42de7f37a2f54464f0939e0562c9540dd3d33f703c0f7bdebc5a
Nov 22 19:30:06 redbull-ncn-m001-pit podman[75145]: 2022-11-22 19:30:06.503070941 +0000 UTC m=+0.069294473 image pull  artifactory.algol60.net/csm-docker/unstable/metal-basecamp:1.2.2_1_gaec949b
Nov 22 19:30:06 redbull-ncn-m001-pit basecamp-init.sh[75198]: time="2022-11-22T19:30:06Z" level=warning msg="Path \"/etc/SUSEConnect\" from \"/etc/containers/mounts.conf\" doesn't exist, skipping"
Nov 22 19:30:06 redbull-ncn-m001-pit basecamp-init.sh[75198]: time="2022-11-22T19:30:06Z" level=warning msg="Path \"/etc/zypp/credentials.d/SCCcredentials\" from \"/etc/containers/mounts.conf\" doesn't exist, skipping"
Nov 22 19:30:06 redbull-ncn-m001-pit podman[75198]: 2022-11-22 19:30:06.852266952 +0000 UTC m=+0.240561645 container init fe7b800498fa42de7f37a2f54464f0939e0562c9540dd3d33f703c0f7bdebc5a (image=artifactory.algol60.net/csm-docker/unstable/metal-basecamp:1.2.2_1_gaec949b, name=basec>
Nov 22 19:30:06 redbull-ncn-m001-pit podman[75198]: 2022-11-22 19:30:06.87084882 +0000 UTC m=+0.259143504 container start fe7b800498fa42de7f37a2f54464f0939e0562c9540dd3d33f703c0f7bdebc5a (image=artifactory.algol60.net/csm-docker/unstable/metal-basecamp:1.2.2_1_gaec949b, name=basec>
Nov 22 19:30:06 redbull-ncn-m001-pit basecamp-init.sh[75198]: basecamp
Nov 22 19:30:06 redbull-ncn-m001-pit conmon[75250]: 2022/11/22 19:30:06 Severing static files located here:  ./static/
Nov 22 19:30:07 redbull-ncn-m001-pit systemd[1]: Started Basecamp cloud-init server.
redbull-ncn-m001-pit:~ # podman container list
CONTAINER ID  IMAGE                                                                        COMMAND               CREATED         STATUS             PORTS       NAMES
0a1a49756c57  artifactory.algol60.net/csm-docker/stable/nexus3:3.25.0-2                    sh -c ${SONATYPE_...  2 months ago    Up 8 weeks ago                 nexus
fe7b800498fa  artifactory.algol60.net/csm-docker/unstable/metal-basecamp:1.2.2_1_gaec949b                        16 seconds ago  Up 16 seconds ago              basecamp
```

### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
