### PR TITLE
MTL-1708 Build & Publish SP4 RPMs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-FROM        artifactory.algol60.net/csm-docker/stable/csm-docker-sle-go:1.18 as builder
+ARG         GO_VERSION
+ARG         SLE_VERSION
+FROM        artifactory.algol60.net/csm-docker/stable/csm-docker-sle-go:${GO_VERSION}-SLES${SLE_VERSION} as builder
 WORKDIR     /workspace
 COPY        . ./
 

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -24,6 +24,10 @@
 @Library('csm-shared-library') _
 
 def goImage = 'artifactory.algol60.net/csm-docker/stable/csm-docker-sle-go'
+
+// Define the distro that the major.minor and major.minor.patch Docker tags publish to.
+def mainSleVersion = '15.4'
+
 def isStable = env.TAG_NAME != null ? true : false
 pipeline {
 
@@ -40,9 +44,10 @@ pipeline {
 
     environment {
         DOCKER_ARGS = getDockerBuildArgs(name: getRepoName(), description: 'A cloud-init DataSource.')
-        GO_VERSION = sh(returnStdout: true, script: 'grep -Eo "^go .*" go.mod | cut -d " " -f2').trim()
         NAME = getRepoName()
-        VERSION = sh(returnStdout: true, script: "git describe --tags | tr -s '-' '_' | tr -d '^v'").trim()
+        GO_VERSION = sh(returnStdout: true, script: 'grep -Eo "^go .*" go.mod | cut -d " " -f2').trim()
+        IMAGE_VERSION = sh(returnStdout: true, script: "git describe --tags | tr -s '-' '_' | tr -d '^v'").trim()
+        VERSION = sh(returnStdout: true, script: "git describe --tags | tr -s '-' '~' | tr -d '^v'").trim()
     }
 
     stages {
@@ -55,46 +60,81 @@ pipeline {
 
         stage('Publish: Image') {
             steps {
-                publishCsmDockerImage(image: env.NAME, tag: env.VERSION, isStable: isStable)
+                publishCsmDockerImage(image: env.NAME, tag: env.IMAGE_VERSION, isStable: isStable)
             }
         }
 
-        stage('Prepare: RPMs') {
-            agent {
-                docker {
-                    label 'docker'
-                    reuseNode true
-                    image "${goImage}:${env.GO_VERSION}"
+        stage('Build & Publish: RPM') {
+
+            matrix {
+
+                agent {
+                    node {
+                        label "metal-gcp-builder"
+                        customWorkspace "${env.WORKSPACE}/${sleVersion}/${env.GO_VERSION}"
+                    }
                 }
-            }
-            steps {
-                runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
-                sh "make rpm_prepare"
-                sh "git update-index --assume-unchanged ${env.NAME}.spec"
-            }
-        }
 
-        stage('Build: RPMs') {
-            agent {
-                docker {
-                    label 'docker'
-                    reuseNode true
-                    image "${goImage}:${env.GO_VERSION}"
-                    args "-v ${env.WORKSPACE}:/workspace"
+                axes {
+                    axis {
+                        name 'sleVersion'
+                        values 15.3, 15.4
+                    }
                 }
-            }
-            steps {
-                sh "make rpm"
-            }
-        }
 
-        stage('Publish: RPMs') {
-            steps {
-                script {
-                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", os: "sle-15sp2", arch: "x86_64", isStable: isStable)
-                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", os: "sle-15sp3", arch: "x86_64", isStable: isStable)
-                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: "sle-15sp2", arch: "src", isStable: isStable)
-                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: "sle-15sp3", arch: "src", isStable: isStable)
+                stages {
+
+                    stage('Prepare: RPMs') {
+                        agent {
+                            docker {
+                                label 'docker'
+                                reuseNode true
+                                image "${goImage}:${env.GO_VERSION}-SLES${sleVersion}"
+                            }
+                        }
+                        steps {
+                            runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
+                            sh "make rpm_prepare"
+                            sh "git update-index --assume-unchanged ${env.NAME}.spec"
+                        }
+                    }
+
+                    stage('Build: RPMs') {
+                        agent {
+                            docker {
+                                label 'docker'
+                                reuseNode true
+                                image "${goImage}:${env.GO_VERSION}-SLES${sleVersion}"
+                            }
+                        }
+                        steps {
+                            sh "make rpm"
+                        }
+                    }
+
+                    stage('Publish: RPMs') {
+                        steps {
+                            script {
+                                sles_version_parts = "${sleVersion}".tokenize('.')
+                                sles_major = "${sles_version_parts[0]}"
+                                sles_minor = "${sles_version_parts[1]}"
+                                publishCsmRpms(
+                                        arch: "x86_64",
+                                        component: env.NAME,
+                                        isStable: isStable,
+                                        os: "sle-${sles_major}sp${sles_minor}",
+                                        pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm",
+                                )
+                                publishCsmRpms(
+                                        arch: "src",
+                                        component: env.NAME,
+                                        isStable: isStable,
+                                        os: "sle-${sles_major}sp${sles_minor}",
+                                        pattern: "dist/rpmbuild/SRPMS/*.rpm",
+                                )
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,20 @@ ifeq ($(NAME),)
 NAME := $(shell basename $(shell pwd))
 endif
 
+ifeq ($(IMAGE_VERSION),)
+IMAGE_VERSION := $(shell git describe --tags | tr -s '-' '_' | tr -d '^v')
+endif
+
 ifeq ($(VERSION),)
 VERSION := $(shell git describe --tags | tr -s '-' '~' | tr -d '^v')
+endif
+
+ifeq ($(GO_VERSION),)
+GO_VERSION := $(shell awk -v replace="'" '/goVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
+endif
+
+ifeq ($(SLE_VERSION),)
+SLE_VERSION := $(shell awk -v replace="'" '/mainSleVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
 endif
 
 GO_FILES?=$$(find . -name '*.go' |grep -v vendor)
@@ -152,4 +164,4 @@ version:
 	@go version
 
 image:
-	docker build --pull ${DOCKER_ARGS} --tag '${NAME}:${VERSION}' .
+	docker build --pull ${DOCKER_ARGS} --build-arg SLE_VERSION='${SLE_VERSION}' --build-arg GO_VERSION='${GO_VERSION}' --tag '${NAME}:${IMAGE_VERSION}' .

--- a/go.mod
+++ b/go.mod
@@ -39,4 +39,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.18
+go 1.19


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-1708

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Continue to build and publish SP3 RPMs while publishing SP4 RPMs.
Also upgrade to Go 1.19 since.

    
Update `%preun` and `%postun` to stop and remove the container and images on uninstalls.


Example of the new `%postun` script cleaning up podman:
```bash
redbull-ncn-m001-pit:~ # rpm -ivh https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp4/metal-basecamp/x86_64/metal-basecamp-1.2.3~1~gaa6a58d-1.x86_64.rpm
Retrieving https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp4/metal-basecamp/x86_64/metal-basecamp-1.2.3~1~gaa6a58d-1.x86_64.rpm
warning: Found NDB Packages.db database while attempting bdb backend: using ndb backend.
warning: Found NDB Packages.db database while attempting bdb backend: using ndb backend.
Preparing...                          ################################# [100%]
Updating / installing...
   1:metal-basecamp-1.2.3~1~gaa6a58d-1################################# [100%]
systemctl sredbull-ncn-m001-pit:~ # systemctl start metal-basecamp
Failed to start metal-basecamp.service: Unit metal-basecamp.service not found.
redbull-ncn-m001-pit:~ # systemctl start basecamp
redbull-ncn-m001-pit:~ # rpm -ivh https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp4/metal-basecamp/x86_64/metal-basecamp-1.2.3~1~gaa6a58d-1.x86_64.rpm^C
redbull-ncn-m001-pit:~ # podman ps -a
CONTAINER ID  IMAGE                                                                        COMMAND               CREATED        STATUS             PORTS       NAMES
c9f1aaf8941f  artifactory.algol60.net/csm-docker/stable/nexus3:3.37.0                      sh -c ${SONATYPE_...  4 days ago     Up 12 minutes ago              nexus
0aa93fc7e636  artifactory.algol60.net/csm-docker/unstable/metal-basecamp:1.2.3_1_gaa6a58d                        4 seconds ago  Up 4 seconds ago               basecamp
redbull-ncn-m001-pit:~ # rpm -e metal-basecamp
warning: Found NDB Packages.db database while attempting bdb backend: using ndb backend.
warning: Found NDB Packages.db database while attempting bdb backend: using ndb backend.
rm: cannot remove '/var/lib/systemd/migrated/basecamp': No such file or directory
basecamp
0aa93fc7e63628a34824d5a838a654a7e6820935e8361400f08932cc9a0b80b2
Untagged: artifactory.algol60.net/csm-docker/unstable/metal-basecamp:1.2.3_1_gaa6a58d
Deleted: eaa2f62b906b66d3e4f702ff21f2e5edfb91cc4f005d3d27b377b7860fd70487
```

The SLES 15SP3 build creates an RPM with SP3 metadata and publishes it to `sle-15sp3`:

```bash
Name        : metal-basecamp
Version     : 1.2.3~1~gaa6a58d
Release     : 1
Architecture: x86_64
Install Date: (not installed)
Group       : Unspecified
Size        : 22474049
License     : MIT License
Signature   : (none)
Source RPM  : metal-basecamp-1.2.3~1~gaa6a58d-1.src.rpm
Build Date  : Fri 02 Dec 2022 09:15:27 PM UTC
Build Host  : 65e797fb4572
Relocations : (not relocatable)
Vendor      : Cray Inc.
URL         : https://github.com/Cray-HPE/metal-basecamp.git
Summary     : Datasource for cloud-init metadata
Description :
Git Repository: metal-basecamp
Git Branch: MTL-1708-SP4
Git Commit Revision: aa6a58dc
Git Commit Timestamp: Fri Dec 2 15:10:54 2022 -0600

A cloud-init datasource that runs out of podman.
Distribution: SUSE Linux Enterprise Server 15 SP3
```

The SLES 15SP4 build creates an RPM with SP4 metadata, and publishes it to `sle-15sp4`:

```bash
Name        : metal-basecamp
Version     : 1.2.3~1~gaa6a58d
Release     : 1
Architecture: x86_64
Install Date: (not installed)
Group       : Unspecified
Size        : 22474049
License     : MIT License
Signature   : (none)
Source RPM  : metal-basecamp-1.2.3~1~gaa6a58d-1.src.rpm
Build Date  : Fri 02 Dec 2022 09:15:30 PM UTC
Build Host  : 5403ea5150a2
Relocations : (not relocatable)
Packager    : https://www.suse.com/
Vendor      : Cray Inc.
URL         : https://github.com/Cray-HPE/metal-basecamp.git
Summary     : Datasource for cloud-init metadata
Description :
Git Repository: metal-basecamp
Git Branch: MTL-1708-SP4
Git Commit Revision: aa6a58dc
Git Commit Timestamp: Fri Dec 2 15:10:54 2022 -0600

A cloud-init datasource that runs out of podman.
Distribution: SUSE Linux Enterprise Server 15 SP4
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
