### PR TITLE
Fix Stable Builds

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,18 +1,18 @@
 /*
  MIT License
- 
+
  (C) Copyright 2022 Hewlett Packard Enterprise Development LP
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),
  to deal in the Software without restriction, including without limitation
  the rights to use, copy, modify, merge, publish, distribute, sublicense,
  and/or sell copies of the Software, and to permit persons to whom the
  Software is furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included
  in all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -45,6 +45,7 @@ pipeline {
     environment {
         DOCKER_ARGS = getDockerBuildArgs(name: getRepoName(), description: 'A cloud-init DataSource.')
         NAME = getRepoName()
+        IS_STABLE = "${isStable}"
         GO_VERSION = sh(returnStdout: true, script: 'grep -Eo "^go .*" go.mod | cut -d " " -f2').trim()
         IMAGE_VERSION = sh(returnStdout: true, script: "git describe --tags | tr -s '-' '_' | tr -d '^v'").trim()
         VERSION = sh(returnStdout: true, script: "git describe --tags | tr -s '-' '~' | tr -d '^v'").trim()


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: Stable builds

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- Docs Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Stable builds key off of `IS_STABLE` to resolve which image to pull into the RPM. The `IS_STABLE` env. var. was removed in a previous PR.

This adds `IS_STABLE` back in to allow stable builds to work again.

See `make rpm` step output from this build: https://jenkins.algol60.net/blue/organizations/jenkins/Cray-HPE%2Fmetal-basecamp/detail/v1.2.5/2/pipeline/

```bash
[2023-02-28T22:15:53.971Z] + echo bucket: csm-docker/unstable tag: 1.2.5 current_branch: v1.2.5
[2023-02-28T22:15:53.971Z] bucket: csm-docker/unstable tag: 1.2.5 current_branch: v1.2.5
[2023-02-28T22:15:53.971Z] + timeout 15m sh -c 'until skopeo inspect docker://artifactory.algol60.net/csm-docker/unstable/metal-basecamp:1.2.5; do sleep 10; done'
[2023-02-28T22:15:54.228Z] time="2023-02-28T22:15:54Z" level=fatal msg="Error parsing image name \"docker://artifactory.algol60.net/csm-docker/unstable/metal-basecamp:1.2.5\": Error reading manifest 1.2.5 in artifactory.algol60.net/csm-docker/unstable/metal-basecamp: manifest unknown: The named manifest is not known to the registry."
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
