### PR TITLE
fix rpm spec postrun

### DIFF
--- a/metal-basecamp.spec
+++ b/metal-basecamp.spec
@@ -99,7 +99,7 @@ rm -f %{image_tar}
 if [ $1 -eq 0 ] ; then
     podman stop %{short_name}
     podman rm %{short_name}
-    podman rmi %{name}
+    podman rmi %{image}
 fi
 
 %files


### PR DESCRIPTION
### Summary and Scope

remove image not short_name

Fixes this error:
```
hp-sles:/tmp/basecamp # rpm -e metal-basecamp
basecamp
basecamp
Error: metal-basecamp: image not known
warning: %postun(metal-basecamp-1.2.6~2~ge29d3e5-1.x86_64) scriptlet failed, exit status 1
```

#### Issue Type

- Bugfix Pull Request

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)

 
### Idempotency
 
yes
 
### Risks and Mitigations
 
none known